### PR TITLE
Placeholder for switching to build commands

### DIFF
--- a/app/commands/build_command.rb
+++ b/app/commands/build_command.rb
@@ -1,0 +1,9 @@
+class BuildCommand < ROM::SQL::Commands::Create
+  # TODO: Don't register on specific relation - this command should be generic
+  relation :projects
+  register_as :build
+
+  def execute(tuple)
+    # TODO: Replace with equivalent of: `root.mapper.model.new(attributes)` from the repo
+  end
+end

--- a/app/repositories/application_repository.rb
+++ b/app/repositories/application_repository.rb
@@ -3,6 +3,7 @@ class ApplicationRepository < ROM::Repository::Root
 
   struct_namespace ::Entities
 
+  # TODO: Replace it by `build` command
   def build(attributes = {})
     root.mapper.model.new(attributes)
   end

--- a/app/repositories/project_repository.rb
+++ b/app/repositories/project_repository.rb
@@ -1,3 +1,5 @@
 class ProjectRepository < ApplicationRepository[:projects]
+  # TODO: Switch to
+  # commands :build, :create, update: :by_pk, delete: :by_pk
   commands :create, update: :by_pk, delete: :by_pk
 end


### PR DESCRIPTION
This PR is a placeholder to demonstrate switching from `ApplicationRepository#build` method to generic `BuildCommand` class.